### PR TITLE
feat(publish): add platforms input for multi-arch builds

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -58,6 +58,12 @@ on:
         type: boolean
         default: false
 
+      platforms:
+        description: 'Comma-separated list of target platforms for buildx (e.g. "linux/amd64,linux/arm64"). When empty (default), buildx builds only for the runner''s native platform. When set, QEMU is installed and a multi-platform manifest list is published.'
+        required: false
+        type: string
+        default: ''
+
     secrets:
       docker_password:
         description: 'Docker password for registry login. Default: GITHUB_TOKEN'
@@ -173,6 +179,7 @@ jobs:
         context: ${{ matrix.config.context }}
         push: ${{ inputs.push }}
         file: ${{ matrix.config.dockerfile }}
+        platforms: ${{ inputs.platforms }}
         tags: |
           ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ jobs:
 | `tag_branch_on_pr` | Tag images with the branch name on PR events | No | `false` |
 | `tag_sha` | Tag images with the commit SHA | No | `false` |
 | `tag_branch_sha` | Tag images with `branch-sha` format | No | `false` |
+| `platforms` | Comma-separated buildx target platforms (e.g. `linux/amd64,linux/arm64`). Empty = native only. | No | `""` |
 
 ### Secrets
 
@@ -216,3 +217,20 @@ permissions:
   contents: read       # For accessing repository contents
   pull-requests: write # For posting PR comments
 ```
+
+#### Multi-Platform Builds
+
+Build a manifest list for multiple platforms (QEMU is set up automatically):
+
+```yaml
+jobs:
+  publish:
+    uses: unbounded-tech/workflows-containers/.github/workflows/publish.yaml@main
+    with:
+      platforms: linux/amd64,linux/arm64
+```
+
+This is the right shape for images that need to run on mixed-arch
+clusters (e.g. arm64 EKS nodes). When `platforms` is empty (the default)
+the image is built only for the runner's native platform — the existing
+behavior is preserved.


### PR DESCRIPTION
## Summary

- New optional `platforms` input on `publish.yaml`, forwarded to `docker/build-push-action`'s `platforms:` parameter.
- Default is empty string so existing consumers stay on single-arch (no behavior change).
- QEMU was already set up unconditionally — passing e.g. `linux/amd64,linux/arm64` Just Works.

## Why

[`hops-ops/authstack-reconciler`](https://github.com/hops-ops/authstack-reconciler) needs to run on arm64 EKS nodes; today the workflow publishes amd64-only and the pod can't pull. With this input the consumer just adds:

\`\`\`yaml
with:
  platforms: linux/amd64,linux/arm64
\`\`\`

## Test plan

- [x] README updated with the new input and an example
- [ ] Consumer (authstack-reconciler) flips to \`platforms: linux/amd64,linux/arm64\` and verifies a multi-arch manifest list lands at the published tag

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workflow now accepts a `platforms` input parameter to enable multi-platform Docker builds via Buildx.

* **Documentation**
  * Updated documentation with multi-platform build configuration instructions and usage examples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unbounded-tech/workflows-containers/pull/27)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->